### PR TITLE
Create initial Kotlin Spring Boot sample application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Kotlin Spring Boot Demo Application
+
+This is a sample web application built with Spring Boot 3.3.0, Kotlin 1.9.23, and Java 21.
+
+## Prerequisites
+
+- Java 21 or higher
+- Gradle (the project uses the Gradle wrapper, so a local installation is not strictly required)
+
+## Building the Application
+
+To build the application, run the following command in the project root:
+
+```bash
+./gradlew build
+```
+
+This will compile the code and run the unit tests.
+
+## Running the Application
+
+To run the application, use the following command:
+
+```bash
+./gradlew bootRun
+```
+
+The application will start, and you can access it at `http://localhost:8080`.
+
+## Available Endpoints
+
+- `GET /hello`: Returns a "Hello, Spring Boot with Kotlin!" message.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,48 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    id("org.springframework.boot") version "3.3.0"
+    id("io.spring.dependency-management") version "1.1.5"
+    kotlin("jvm") version "1.9.23"
+    kotlin("plugin.spring") version "1.9.23"
+    id("java")
+}
+
+group = "com.example"
+version = "0.0.1-SNAPSHOT"
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    testImplementation("org.springframework.boot:spring-boot-starter-test") {
+        exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
+    }
+    testImplementation(kotlin("test"))
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        freeCompilerArgs = listOf("-Xjsr305=strict")
+        jvmTarget = "21"
+    }
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+
+springBoot {
+    mainClass.set("com.example.demo.DemoApplicationKt")
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "kotlin-spring-demo"

--- a/src/main/kotlin/com/example/demo/DemoApplication.kt
+++ b/src/main/kotlin/com/example/demo/DemoApplication.kt
@@ -1,0 +1,11 @@
+package com.example.demo
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class DemoApplication
+
+fun main(args: Array<String>) {
+    runApplication<DemoApplication>(*args)
+}

--- a/src/main/kotlin/com/example/demo/controller/HelloController.kt
+++ b/src/main/kotlin/com/example/demo/controller/HelloController.kt
@@ -1,0 +1,13 @@
+package com.example.demo.controller
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class HelloController {
+
+    @GetMapping("/hello")
+    fun hello(): String {
+        return "Hello, Spring Boot with Kotlin!"
+    }
+}

--- a/src/test/kotlin/com/example/demo/controller/HelloControllerTest.kt
+++ b/src/test/kotlin/com/example/demo/controller/HelloControllerTest.kt
@@ -1,0 +1,25 @@
+package com.example.demo.controller
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.junit.jupiter.api.Test
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class HelloControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `should return hello message`() {
+        mockMvc.perform(get("/hello"))
+            .andExpect(status().isOk)
+            .andExpect(content().string("Hello, Spring Boot with Kotlin!"))
+    }
+}


### PR DESCRIPTION
This commit introduces a basic Spring Boot web application using Kotlin.

Features:
- Spring Boot 3.3.0
- Kotlin 1.9.23
- Java 21
- A simple REST controller with a GET endpoint at /hello
- A unit test for the controller
- Gradle build configuration
- README file with build and run instructions.

The application serves as a starting point for developing web applications with Kotlin and Spring Boot.