### PR TITLE
feat: Add user CRUD functionality with H2 database

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kotlin Spring Boot Demo Application
 
-This is a sample web application built with Spring Boot 3.3.0, Kotlin 1.9.23, and Java 21.
+This is a sample web application built with Spring Boot 3.3.0, Kotlin 1.9.23, and Java 21. It includes a REST API for managing users and uses an H2 in-memory database.
 
 ## Prerequisites
 
@@ -30,3 +30,27 @@ The application will start, and you can access it at `http://localhost:8080`.
 ## Available Endpoints
 
 - `GET /hello`: Returns a "Hello, Spring Boot with Kotlin!" message.
+
+### User API Endpoints (`/api/users`)
+
+- `POST /api/users`: Creates a new user.
+  - Request Body: JSON object with `username` and `email`.
+    ```json
+    {
+      "username": "newuser",
+      "email": "newuser@example.com"
+    }
+    ```
+- `GET /api/users/{id}`: Retrieves a specific user by their ID.
+- `GET /api/users`: Retrieves a list of all users.
+
+## H2 Database Console
+
+When the application is running, you can access the H2 in-memory database console in your browser.
+
+- **URL**: `http://localhost:8080/h2-console`
+- **JDBC URL**: `jdbc:h2:mem:testdb` (this should be pre-filled)
+- **User Name**: `sa`
+- **Password**: (leave blank)
+
+Click "Connect" to access the database tables and run SQL queries.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,9 +23,11 @@ repositories {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    runtimeOnly("com.h2database:h2")
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }

--- a/src/main/kotlin/com/example/demo/controller/UserController.kt
+++ b/src/main/kotlin/com/example/demo/controller/UserController.kt
@@ -1,0 +1,32 @@
+package com.example.demo.controller
+
+import com.example.demo.model.User
+import com.example.demo.repository.UserRepository
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+// ResponseStatusException is not needed if using ResponseEntity for getUserById
+// import org.springframework.web.server.ResponseStatusException 
+
+@RestController
+@RequestMapping("/api/users")
+class UserController(private val userRepository: UserRepository) {
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createUser(@RequestBody user: User): User {
+        return userRepository.save(user)
+    }
+
+    @GetMapping("/{id}")
+    fun getUserById(@PathVariable id: Long): ResponseEntity<User> {
+        return userRepository.findById(id)
+            .map { user -> ResponseEntity.ok(user) }
+            .orElse(ResponseEntity.notFound().build())
+    }
+
+    @GetMapping
+    fun getAllUsers(): List<User> {
+        return userRepository.findAll()
+    }
+}

--- a/src/main/kotlin/com/example/demo/model/User.kt
+++ b/src/main/kotlin/com/example/demo/model/User.kt
@@ -1,0 +1,19 @@
+package com.example.demo.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+
+@Entity
+data class User(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @Column(unique = true)
+    var username: String,
+
+    var email: String
+)

--- a/src/main/kotlin/com/example/demo/repository/UserRepository.kt
+++ b/src/main/kotlin/com/example/demo/repository/UserRepository.kt
@@ -1,0 +1,11 @@
+package com.example.demo.repository
+
+import com.example.demo.model.User
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository // Optional, Spring Data JPA repositories are automatically detected
+interface UserRepository : JpaRepository<User, Long> {
+    // You can add custom query methods here if needed later
+    // For example: fun findByUsername(username: String): User?
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,13 @@
+# H2 Database Configuration
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+
+# JPA Configuration
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true

--- a/src/test/kotlin/com/example/demo/controller/UserControllerTest.kt
+++ b/src/test/kotlin/com/example/demo/controller/UserControllerTest.kt
@@ -1,0 +1,79 @@
+package com.example.demo.controller
+
+import com.example.demo.model.User
+import com.example.demo.repository.UserRepository
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.AfterEach
+// import org.junit.jupiter.api.Assertions.assertEquals // Not strictly needed if using jsonPath assertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @AfterEach
+    fun tearDown() {
+        userRepository.deleteAll()
+    }
+
+    @Test
+    fun `testCreateUserAndGetUserById`() {
+        val newUser = User(username = "testuser", email = "test@example.com")
+
+        val resultActions = mockMvc.perform(post("/api/users")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(newUser)))
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.username").value(newUser.username))
+            .andExpect(jsonPath("$.email").value(newUser.email))
+            .andExpect(jsonPath("$.id").exists())
+
+        val responseString = resultActions.andReturn().response.contentAsString
+        val createdUser = objectMapper.readValue(responseString, User::class.java)
+        val userId = createdUser.id!! // id should not be null as it's generated and checked by jsonPath("$.id").exists()
+
+        mockMvc.perform(get("/api/users/{id}", userId))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.username").value(newUser.username))
+            .andExpect(jsonPath("$.email").value(newUser.email))
+    }
+
+    @Test
+    fun `testGetAllUsers`() {
+        val user1 = User(username = "userone", email = "user1@example.com")
+        val user2 = User(username = "usertwo", email = "user2@example.com")
+        userRepository.saveAll(listOf(user1, user2))
+
+        mockMvc.perform(get("/api/users"))
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.size()").value(2))
+            // Order is not guaranteed by findAll, so check for presence or sort if specific order is needed
+            // For simplicity, assuming order or checking for specific elements:
+            .andExpect(jsonPath("$[?(@.username == 'userone')]").exists())
+            .andExpect(jsonPath("$[?(@.username == 'usertwo')]").exists())
+    }
+    
+    @Test
+    fun `testGetUserById_NotFound`() {
+        val nonExistentId = 9999L // Use a Long type for ID
+        mockMvc.perform(get("/api/users/{id}", nonExistentId))
+            .andExpect(status().isNotFound)
+    }
+}


### PR DESCRIPTION
This commit introduces user management features, allowing clients to create, retrieve, and list users. User data is stored in an H2 in-memory database.

Key changes:
- Added Spring Data JPA and H2 dependencies.
- Defined a User entity with id, username, and email.
- Created UserRepository extending JpaRepository.
- Configured application.properties for H2 datasource, H2 console, and JPA (ddl-auto=update, show-sql=true).
- Implemented UserController with the following REST endpoints:
    - POST /api/users: Creates a new user.
    - GET /api/users/{id}: Retrieves a user by ID.
    - GET /api/users: Retrieves all users.
- Added integration tests for UserController, covering user creation, retrieval by ID (including not found scenario), and listing all users.
- Updated README.md with documentation for the new User API endpoints and instructions for accessing the H2 console.